### PR TITLE
Add WaveShare epaper board firmware link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,6 +40,7 @@ A curated list of TRMNL docs, talks, tools, examples & articles the internet has
 
 ## ⚡Firmware & Firmware flashing
 - [TRMNL firmware](https://github.com/usetrmnl/firmware)
+- [WaveShare ESP32-WROOM epaper board TRMNL Firmware](https://github.com/JayJay1989/firmware)
 - [TRMNL browser firmware flashing](https://usetrmnl.com/flash) - Flash your TRMNL firmware in browser
 - [ESPHome firmware](https://github.com/jesserockz/esphome-trmnl) - ESPHome firmware for TRMNL
 


### PR DESCRIPTION
Ported the firmware to the waveshare esp32 epaper board with waveshare 7.5 inch eink display.
