### PR TITLE
update readme.md to link to the new BYOS repo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ A curated list of TRMNL docs, talks, tools, examples & articles the internet has
 
 ## 📄 Official Docs & Quickstarts
 - [useTRMNL](https://docs.usetrmnl.com/)
-- [TRMNL DIY server](https://github.com/usetrmnl/byos_sinatra) - Self hosted screen generation in Ruby/Sinatra
+- [Terminus](https://github.com/usetrmnl/byos_hanami) - Self hosted screen generation in Ruby/Hanami maintained by the TRMNL team
 
 ## ⚡Firmware & Firmware flashing
 - [TRMNL firmware](https://github.com/usetrmnl/firmware)


### PR DESCRIPTION
It looks like the byos_sinatra repo has been updated w/ documentation directing to their Terminus implementation.

Relevant commit: https://github.com/usetrmnl/byos_sinatra/commit/48a618ecb66133c6bf5f125e0213e13d8be7d9ba

This updates the link to point to point to the Terminus repo.